### PR TITLE
removes form reset and submission blocking on form dirty

### DIFF
--- a/src/components/SettingsForm.test.tsx
+++ b/src/components/SettingsForm.test.tsx
@@ -42,7 +42,6 @@ describe("SettingsForm component", () => {
         onSubmit={mockOnSubmit}
       />
     );
-    const submitButton = await screen.findByTestId("settings-form-submit");
     const tokenField = await screen.findByTestId("settings-form-field-token");
     const urlField = await screen.findByTestId("settings-form-field-url");
     const glucoseUnitsSelect = await screen.findByTestId(
@@ -50,7 +49,6 @@ describe("SettingsForm component", () => {
     );
 
     expect(container.firstChild).toMatchSnapshot();
-    expect(submitButton).not.toBeEnabled();
     expect(tokenField).toHaveValue(mockNsToken);
     expect(urlField).toHaveValue(mockNsUrl);
     expect(glucoseUnitsSelect).toHaveValue(mockGlucoseUnits);

--- a/src/components/SettingsForm.tsx
+++ b/src/components/SettingsForm.tsx
@@ -79,21 +79,15 @@ export default function SettingsForm({
 }: SettingsFormProps) {
   const classes = useStyles();
   // eslint-disable-next-line
-  const {
-    control,
-    formState,
-    getValues,
-    handleSubmit,
-    register,
-    reset: resetForm,
-  } = useForm<SettingsFormData>();
+  const { control, formState, getValues, handleSubmit, register } = useForm<
+    SettingsFormData
+  >();
   const { t } = useTranslation();
   const [formHasSubmissionError, setFormHasSubmissionError] = useState(false);
   const [formHasSubmittedSuccess, setFormHasSubmittedSuccess] = useState(false);
   const [tokenDialogOpen, setTokenDialogOpen] = useState(false);
 
   const canEditFields = !formState.isSubmitting;
-  const canSubmitForm = formState.isDirty && !formState.isSubmitting;
 
   const glucoseUnits = Object.entries(BloodGlucoseUnits).map(([_, v]) => {
     return { label: v, value: v };
@@ -118,7 +112,7 @@ export default function SettingsForm({
 
   const formReset = () => {
     setFormHasSubmissionError(false);
-    resetForm();
+    setFormHasSubmittedSuccess(false);
   };
 
   const handleFormAlertClose = () => {
@@ -275,7 +269,6 @@ export default function SettingsForm({
         <Button
           color="primary"
           data-testid="settings-form-submit"
-          disabled={!canSubmitForm}
           type="submit"
           variant="contained"
         >

--- a/src/components/__snapshots__/SettingsForm.test.tsx.snap
+++ b/src/components/__snapshots__/SettingsForm.test.tsx.snap
@@ -413,10 +413,9 @@ exports[`SettingsForm component renders the component 1`] = `
     class="MuiContainer-root MuiContainer-disableGutters MuiContainer-maxWidthLg"
   >
     <button
-      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary Mui-disabled Mui-disabled"
+      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
       data-testid="settings-form-submit"
-      disabled=""
-      tabindex="-1"
+      tabindex="0"
       type="submit"
     >
       <span
@@ -424,6 +423,9 @@ exports[`SettingsForm component renders the component 1`] = `
       >
         settings.form.submitButton
       </span>
+      <span
+        class="MuiTouchRipple-root"
+      />
     </button>
   </div>
 </form>

--- a/src/pages/__snapshots__/EditSettings.test.tsx.snap
+++ b/src/pages/__snapshots__/EditSettings.test.tsx.snap
@@ -425,10 +425,9 @@ exports[`EditSettings Renders the component when loading, with no axe violations
       class="MuiContainer-root MuiContainer-disableGutters MuiContainer-maxWidthLg"
     >
       <button
-        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary Mui-disabled Mui-disabled"
+        class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary"
         data-testid="settings-form-submit"
-        disabled=""
-        tabindex="-1"
+        tabindex="0"
         type="submit"
       >
         <span
@@ -436,6 +435,9 @@ exports[`EditSettings Renders the component when loading, with no axe violations
         >
           settings.form.submitButton
         </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
       </button>
     </div>
   </form>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- The template is a guideline, not a test :) All PRs are welcome! -->

## Description
In this PR we're fixing a bug with form reverting to its original state after a save due to incorrect use of the form reset method. We're fixing it by 1) removing the call to reset, and 2) removing the "disable save button until form is dirty" behaviour, which gets broken by the removed call to reset.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've made my changes in a separate `fix/` or `feature/` branch
- [ ] My change requires a change to the documentation/website
- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
- [x] I've written tests to cover my change
- [x] My change is passing new and existing tests
