### PR TITLE
API url clean up

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -4,6 +4,14 @@
     "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
     "rewrites": [
       {
+        "source": "/api/v1/validate-nightscout",
+        "function": "validateNightscoutUrl"
+      },
+      {
+        "source": "/api/v1/handle-conversation",
+        "function": "conversation"
+      },
+      {
         "source": "**",
         "destination": "/index.html"
       }


### PR DESCRIPTION
## Description
This will make the webhooks accessible from the hosting domain.  
- `https://us-central1-gluco-check-nightly.cloudfunctions.net/conversation?v=1`
  ==> `https://gluco-check-nightly.web.app/api/v1/handle-conversation`
- `https://us-central1-gluco-check-nightly.cloudfunctions.net/validateNightscoutUrl`
   ==> `https://gluco-check-nightly.web.app/api/v1/validate-nightscout`

## Motivation and Context
Frontend will be able to use `/api/v1/...` instead of a long and complex url

## How Has This Been Tested?
It hasn't 🙃 

## Screenshots (if appropriate):

## Types of changes
New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I've made my changes in a separate `fix/` or `feature/` branch
- [ ] My change requires a change to the documentation/website
- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
- [ ] I've written tests to cover my change
- [ ] My change is passing new and existing tests
