### PR TITLE
BUGFIX: issue with checkbox series styling

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -52,7 +52,7 @@
         "defaultMetrics": {
           "default": "Assistant will read these items to you by default",
           "required": "You must select at least one metric",
-          "notAvailable": "We did not find a recent value for these metrics, but you can still select them"
+          "notAvailable": "* We did not find a recent value for these metrics, but you can still select them"
         },
         "glucoseUnits": {
           "mismatch": "Chosen unit differs from your Nightscout site's units"

--- a/public/locales/nl/translation.json
+++ b/public/locales/nl/translation.json
@@ -52,7 +52,7 @@
         "defaultMetrics": {
           "default": "[Assistant will read these items to you by default]",
           "required": "[You must select at least one metric]",
-          "notAvailable": "[We did not find a recent value for these metrics, but you can still select them]"
+          "notAvailable": "[* We did not find a recent value for these metrics, but you can still select them]"
         },
         "glucoseUnits": {
           "mismatch": "[Chosen unit differs from your Nightscout site's units]"

--- a/src/components/SettingsForm.tsx
+++ b/src/components/SettingsForm.tsx
@@ -71,7 +71,6 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   helperWarning: {
-    color: theme.palette.warning.main,
     "& .MuiFormLabel-root, & .MuiInputBase-root, & .MuiInputBase-input, & .MuiFormHelperText-root, & .MuiSelect-root": {
       color: theme.palette.warning.main,
     },


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- The template is a guideline, not a test :) All PRs are welcome! -->

## Description
`helperWarning` styles had one overly broad colour declaration that caused the labels of non-warned checkboxes to improperly take on the warning colour. In this PR we are removing that style. And at the same time, we're adding an asterisk preceding the "metric not available" warning message to match the asterisks next to the checkboxes themselves.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've made my changes in a separate `fix/` or `feature/` branch
- [ ] My change requires a change to the documentation/website
- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
- [ ] I've written tests to cover my change
- [ ] My change is passing new and existing tests
