### PR TITLE
feature/language-selector

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "i18next": "^19.8.2",
     "i18next-browser-languagedetector": "^6.0.1",
     "i18next-http-backend": "^1.0.21",
+    "material-ui-popup-state": "^1.7.1",
     "pure-react-carousel": "^1.27.6",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -136,8 +136,11 @@
       "image_alt": ""
     }
   },
-  "availableLanguageLabels": {
-    "en": "English",
-    "nl": "Dutch"
+  "languageSelector": {
+    "buttonLabel": "Language",
+    "availableLanguageLabels": {
+      "en": "English",
+      "nl": "Dutch"
+    }
   }
 }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -135,5 +135,9 @@
       "image": "copy-token.png",
       "image_alt": ""
     }
+  },
+  "availableLanguageLabels": {
+    "en": "English",
+    "nl": "Dutch"
   }
 }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -11,7 +11,8 @@
     "healthDisclaimer": "/terms",
     "privacy": "/terms",
     "nightscoutProject": "http://nightscout.info/",
-    "faqs": "/faq"
+    "faqs": "/faq",
+    "translations": "https://google.com"
   },
   "landing": {
     "title": "Welcome to Gluco Check",
@@ -138,6 +139,7 @@
   },
   "languageSelector": {
     "buttonLabel": "Language",
+    "contribute": "Contribute Translations",
     "availableLanguageLabels": {
       "en": "English",
       "nl": "Dutch"

--- a/public/locales/nl/translation.json
+++ b/public/locales/nl/translation.json
@@ -136,8 +136,11 @@
       "image_alt": ""
     }
   },
-  "availableLanguageLabels": {
-    "en": "[English]",
-    "nl": "[Dutch]"
+  "languageSelector": {
+    "buttonLabel": "[Language]",
+    "availableLanguageLabels": {
+      "en": "[English]",
+      "nl": "[Dutch]"
+    }
   }
 }

--- a/public/locales/nl/translation.json
+++ b/public/locales/nl/translation.json
@@ -11,7 +11,8 @@
     "healthDisclaimer": "/terms/nl",
     "privacy": "/terms/nl",
     "nightscoutProject": "http://nightscout.info/",
-    "faqs": "/faq/nl"
+    "faqs": "/faq/nl",
+    "translations": "https://google.com"
   },
   "landing": {
     "title": "Welkom bij Gluco Check",
@@ -138,6 +139,7 @@
   },
   "languageSelector": {
     "buttonLabel": "[Language]",
+    "contribute": "[Contribute Translations]",
     "availableLanguageLabels": {
       "en": "[English]",
       "nl": "[Dutch]"

--- a/public/locales/nl/translation.json
+++ b/public/locales/nl/translation.json
@@ -135,5 +135,9 @@
       "image": "copy-token.png",
       "image_alt": ""
     }
+  },
+  "availableLanguageLabels": {
+    "en": "[English]",
+    "nl": "[Dutch]"
   }
 }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -16,6 +16,15 @@ jest.mock("./lib/firebase.ts", () => {
   };
 });
 
+jest.mock("./components/LanguageSelector.tsx", () => {
+  return {
+    __esModule: true,
+    default: () => {
+      return <div>LanguageSelector</div>;
+    },
+  };
+});
+
 jest.mock("./pages/EditSettings.tsx", () => {
   return {
     __esModule: true,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ import EditSettings from "./pages/EditSettings";
 import Welcome from "./pages/Welcome";
 import "./App.css";
 import LanguageSelector from "./components/LanguageSelector";
+import { AvailableLanguage } from "./lib/enums";
 
 export const FirebaseUserDocumentContext = React.createContext("");
 
@@ -89,9 +90,11 @@ export default function App() {
         </section>
         <section className={classes.rightToolbar}>
           <ul className={classes.nav}>
-            <li>
-              <LanguageSelector></LanguageSelector>
-            </li>
+            {Object.values(AvailableLanguage).length > 1 && (
+              <li>
+                <LanguageSelector />
+              </li>
+            )}
             <li>
               <IconButton
                 aria-label={t("boilerplate.faqs")}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import Landing from "./pages/Landing";
 import EditSettings from "./pages/EditSettings";
 import Welcome from "./pages/Welcome";
 import "./App.css";
+import LanguageSelector from "./components/LanguageSelector";
 
 export const FirebaseUserDocumentContext = React.createContext("");
 
@@ -88,6 +89,9 @@ export default function App() {
         </section>
         <section className={classes.rightToolbar}>
           <ul className={classes.nav}>
+            <li>
+              <LanguageSelector></LanguageSelector>
+            </li>
             <li>
               <IconButton
                 aria-label={t("boilerplate.faqs")}

--- a/src/__snapshots__/App.test.tsx.snap
+++ b/src/__snapshots__/App.test.tsx.snap
@@ -26,6 +26,11 @@ exports[`App component renders the component when no user and no loading 1`] = `
           class="makeStyles-nav-22"
         >
           <li>
+            <div>
+              LanguageSelector
+            </div>
+          </li>
+          <li>
             <a
               aria-disabled="false"
               aria-label="boilerplate.faqs"
@@ -96,6 +101,11 @@ exports[`App component renders the component when user loaded 1`] = `
         <ul
           class="makeStyles-nav-14"
         >
+          <li>
+            <div>
+              LanguageSelector
+            </div>
+          </li>
           <li>
             <a
               aria-disabled="false"
@@ -253,6 +263,11 @@ exports[`App component renders the component when user loading 1`] = `
         <ul
           class="makeStyles-nav-6"
         >
+          <li>
+            <div>
+              LanguageSelector
+            </div>
+          </li>
           <li>
             <a
               aria-disabled="false"

--- a/src/components/LanguageSelector.test.tsx
+++ b/src/components/LanguageSelector.test.tsx
@@ -1,0 +1,50 @@
+import React from "react";
+import { cleanup, render, screen } from "@testing-library/react";
+import { axe } from "jest-axe";
+import LanguageSelector from "./LanguageSelector";
+
+const mockLanguage = "en";
+const mockChangeLanauge = jest.fn();
+jest.mock("react-i18next", () => ({
+  useTranslation: () => {
+    return {
+      t: jest.fn().mockImplementation((i) => {
+        return i;
+      }),
+      i18n: {
+        language: jest.fn().mockReturnValue(mockLanguage),
+        changeLanguage: mockChangeLanauge,
+      },
+    };
+  },
+}));
+
+afterEach(() => {
+  jest.resetAllMocks();
+  cleanup();
+});
+
+describe("LanguageSelector component", () => {
+  it("renders the component, handles clicks and selections", async () => {
+    const { container } = render(<LanguageSelector />);
+    expect(container.firstChild).toMatchSnapshot();
+  });
+
+  it("handles clicks on button and language selections", async () => {
+    const { container } = render(<LanguageSelector />);
+
+    let button = await screen.getByLabelText("languageSelector.buttonLabel");
+    expect(button).toBeInTheDocument();
+    await button.focus();
+    await button.click();
+    expect(screen.getAllByRole("menuitem")[0]).toHaveFocus();
+
+    await screen.getAllByRole("menuitem")[1].click();
+    expect(mockChangeLanauge).toHaveBeenCalled();
+  });
+
+  it("Accessibility: has no axe violations", async () => {
+    const { container } = render(<LanguageSelector />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -1,5 +1,12 @@
-import React, { useRef, useState } from "react";
-import { Button, Hidden, Menu, MenuItem, Paper } from "@material-ui/core";
+import React from "react";
+import {
+  Button,
+  Hidden,
+  makeStyles,
+  Menu,
+  MenuItem,
+  Paper,
+} from "@material-ui/core";
 import { ExpandMore, Translate } from "@material-ui/icons";
 import { useTranslation } from "react-i18next";
 import {
@@ -7,69 +14,75 @@ import {
   bindTrigger,
   bindMenu,
 } from "material-ui-popup-state/hooks";
+import { AvailableLanguage } from "../lib/enums";
 
-export enum AvailableLanguages {
-  English = "en",
-  Dutch = "nl",
-}
+const useStyles = makeStyles((theme) => ({
+  selectorLabel: {
+    marginLeft: theme.spacing(1),
+    marginRight: theme.spacing(1),
+  },
+}));
+
+const MENU_ITEM_ATTRIBUTE = "data-language";
 
 export default function LanguageSelector() {
   const { t, i18n } = useTranslation();
+
+  const classes = useStyles();
 
   const menuState = usePopupState({
     variant: "popover",
     popupId: "languageMenu",
   });
 
-  const [open, setOpen] = useState(false);
-  const anchorRef = useRef<HTMLButtonElement | null>(null);
-
   const handleItemClick = (
     event: React.MouseEvent<HTMLLIElement, MouseEvent>
   ) => {
-    const incomingSelection = event.currentTarget.getAttribute("data-language");
+    const incomingSelection = event.currentTarget.getAttribute(
+      MENU_ITEM_ATTRIBUTE
+    );
     if (
       incomingSelection &&
-      Object.values(AvailableLanguages).includes(
-        incomingSelection as AvailableLanguages
+      Object.values(AvailableLanguage).includes(
+        incomingSelection as AvailableLanguage
       )
     ) {
-      // get language-in-array check working
       i18n.changeLanguage(incomingSelection);
     }
 
     menuState.close();
   };
 
-  // return focus to the button when we transitioned from !open -> open
-  const prevOpen = useRef(open);
-  React.useEffect(() => {
-    if (prevOpen.current === true && open === false) {
-      anchorRef?.current?.focus();
-    }
-    prevOpen.current = open;
-  }, [open]);
-
   return (
     <div>
       <Button
         color="inherit"
-        endIcon={<ExpandMore />}
-        startIcon={<Translate />}
         {...bindTrigger(menuState)}
+        aria-label={t(`languageSelector.buttonLabel`)}
       >
-        <Hidden xsDown>Language</Hidden>
+        <Translate />
+        <Hidden xsDown>
+          <span className={classes.selectorLabel}>
+            {t(`languageSelector.buttonLabel`)}
+          </span>
+        </Hidden>
+        <ExpandMore />
       </Button>
       <Paper>
         <Menu {...bindMenu(menuState)}>
-          {Object.entries(AvailableLanguages).map((value, index) => {
+          {Object.values(AvailableLanguage).map((value, index) => {
+            // console.log("what the heck");
+            const dataProp = {
+              [MENU_ITEM_ATTRIBUTE]: value,
+            };
             return (
               <MenuItem
-                onClick={handleItemClick}
-                data-language={value[1]}
                 key={`language-selector-${index}`}
+                onClick={handleItemClick}
+                selected={value === i18n.language}
+                {...dataProp}
               >
-                {t(`availableLanguageLabels.${value[1]}`)}
+                {t(`languageSelector.availableLanguageLabels.${value}`)}
               </MenuItem>
             );
           })}

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -1,0 +1,80 @@
+import React, { useRef, useState } from "react";
+import { Button, Hidden, Menu, MenuItem, Paper } from "@material-ui/core";
+import { ExpandMore, Translate } from "@material-ui/icons";
+import { useTranslation } from "react-i18next";
+import {
+  usePopupState,
+  bindTrigger,
+  bindMenu,
+} from "material-ui-popup-state/hooks";
+
+export enum AvailableLanguages {
+  English = "en",
+  Dutch = "nl",
+}
+
+export default function LanguageSelector() {
+  const { t, i18n } = useTranslation();
+
+  const menuState = usePopupState({
+    variant: "popover",
+    popupId: "languageMenu",
+  });
+
+  const [open, setOpen] = useState(false);
+  const anchorRef = useRef<HTMLButtonElement | null>(null);
+
+  const handleItemClick = (
+    event: React.MouseEvent<HTMLLIElement, MouseEvent>
+  ) => {
+    const incomingSelection = event.currentTarget.getAttribute("data-language");
+    if (
+      incomingSelection &&
+      Object.values(AvailableLanguages).includes(
+        incomingSelection as AvailableLanguages
+      )
+    ) {
+      // get language-in-array check working
+      i18n.changeLanguage(incomingSelection);
+    }
+
+    menuState.close();
+  };
+
+  // return focus to the button when we transitioned from !open -> open
+  const prevOpen = useRef(open);
+  React.useEffect(() => {
+    if (prevOpen.current === true && open === false) {
+      anchorRef?.current?.focus();
+    }
+    prevOpen.current = open;
+  }, [open]);
+
+  return (
+    <div>
+      <Button
+        color="inherit"
+        endIcon={<ExpandMore />}
+        startIcon={<Translate />}
+        {...bindTrigger(menuState)}
+      >
+        <Hidden xsDown>Language</Hidden>
+      </Button>
+      <Paper>
+        <Menu {...bindMenu(menuState)}>
+          {Object.entries(AvailableLanguages).map((value, index) => {
+            return (
+              <MenuItem
+                onClick={handleItemClick}
+                data-language={value[1]}
+                key={`language-selector-${index}`}
+              >
+                {t(`availableLanguageLabels.${value[1]}`)}
+              </MenuItem>
+            );
+          })}
+        </Menu>
+      </Paper>
+    </div>
+  );
+}

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import {
   Button,
+  Divider,
   Hidden,
   makeStyles,
   Menu,
@@ -71,7 +72,6 @@ export default function LanguageSelector() {
       <Paper>
         <Menu {...bindMenu(menuState)}>
           {Object.values(AvailableLanguage).map((value, index) => {
-            // console.log("what the heck");
             const dataProp = {
               [MENU_ITEM_ATTRIBUTE]: value,
             };
@@ -86,6 +86,14 @@ export default function LanguageSelector() {
               </MenuItem>
             );
           })}
+          <Divider />
+          <MenuItem
+            onClick={() => {
+              window.open(t("urls.translations"), "_blank");
+            }}
+          >
+            {t(`languageSelector.contribute`)}
+          </MenuItem>
         </Menu>
       </Paper>
     </div>

--- a/src/components/__snapshots__/LanguageSelector.test.tsx.snap
+++ b/src/components/__snapshots__/LanguageSelector.test.tsx.snap
@@ -1,0 +1,44 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LanguageSelector component renders the component, handles clicks and selections 1`] = `
+<div>
+  <button
+    aria-haspopup="true"
+    aria-label="languageSelector.buttonLabel"
+    class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-colorInherit"
+    tabindex="0"
+    type="button"
+  >
+    <span
+      class="MuiButton-label"
+    >
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M12.87 15.07l-2.54-2.51.03-.03c1.74-1.94 2.98-4.17 3.71-6.53H17V4h-7V2H8v2H1v1.99h11.17C11.5 7.92 10.44 9.75 9 11.35 8.07 10.32 7.3 9.19 6.69 8h-2c.73 1.63 1.73 3.17 2.98 4.56l-5.09 5.02L4 19l5-5 3.11 3.11.76-2.04zM18.5 10h-2L12 22h2l1.12-3h4.75L21 22h2l-4.5-12zm-2.62 7l1.62-4.33L19.12 17h-3.24z"
+        />
+      </svg>
+      <svg
+        aria-hidden="true"
+        class="MuiSvgIcon-root"
+        focusable="false"
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+        />
+      </svg>
+    </span>
+    <span
+      class="MuiTouchRipple-root"
+    />
+  </button>
+  <div
+    class="MuiPaper-root MuiPaper-elevation1 MuiPaper-rounded"
+  />
+</div>
+`;

--- a/src/lib/enums.ts
+++ b/src/lib/enums.ts
@@ -22,3 +22,8 @@ export enum DiabetesMetric {
   PumpBattery = "pump battery",
   PumpReservoir = "pump reservoir",
 }
+
+export enum AvailableLanguage {
+  English = "en",
+  Dutch = "nl",
+}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -9,8 +9,9 @@ i18n
   .use(LanguageDetector)
   .use(initReactI18next)
   .init({
+    lng: "en",
     fallbackLng: (code) => {
-      const fallback = process.env.REACT_APP_I18N_FALLBACK_LANGUAGE || "en-US";
+      const fallback = process.env.REACT_APP_I18N_FALLBACK_LANGUAGE || "en";
       return [fallback];
     },
     detection: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1649,7 +1649,7 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.11.2":
+"@babel/runtime@^7.1.5", "@babel/runtime@^7.11.2":
   version "7.13.8"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.8.tgz#cc886a85c072df1de23670dc1aa59fc116c4017c"
   integrity sha512-CwQljpw6qSayc0fRG1soxHAKs1CnQMOChm4mlQP6My0kf9upVGizj/KhlTTgyUnETmHpcUXjaluNAkteRFuafg==
@@ -2341,6 +2341,13 @@
     "@material-ui/utils" "^4.9.6"
     csstype "^2.5.2"
     prop-types "^15.7.2"
+
+"@material-ui/types@^4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@material-ui/types/-/types-4.1.1.tgz#b65e002d926089970a3271213a3ad7a21b17f02b"
+  integrity sha512-AN+GZNXytX9yxGi0JOfxHrRTbhFybjUJ05rnsBVjcB+16e466Z0Xe5IxawuOayVZgTBNDxmPKo5j4V6OnMtaSQ==
+  dependencies:
+    "@types/react" "*"
 
 "@material-ui/types@^5.1.0":
   version "5.1.0"
@@ -4452,6 +4459,11 @@ class-validator@^0.12.2:
     google-libphonenumber "^3.2.8"
     tslib ">=1.9.0"
     validator "13.0.0"
+
+classnames@^2.2.6:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+  integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
 
 clean-css@^4.2.3:
   version "4.2.3"
@@ -8900,6 +8912,16 @@ material-design-lite@^1.2.0:
   resolved "https://registry.yarnpkg.com/material-design-lite/-/material-design-lite-1.3.0.tgz#d004ce3fee99a1eeb74a78b8a325134a5f1171d3"
   integrity sha1-0ATOP+6Zoe63Sni4oyUTSl8RcdM=
 
+material-ui-popup-state@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/material-ui-popup-state/-/material-ui-popup-state-1.7.1.tgz#d5856033801a7539072bf79bda396c073b86c95b"
+  integrity sha512-UMXgBBL6KgocJ70HqRnGKUEhSC1Lg1wkVyeLzTPxYrwLRmFUmY83bhOt9rVDTWBLjtaSrO/jRHVSgAu++08RIw==
+  dependencies:
+    "@babel/runtime" "^7.1.5"
+    "@material-ui/types" "^4.1.1"
+    classnames "^2.2.6"
+    prop-types "^15.0.0"
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
@@ -10760,7 +10782,7 @@ prompts@2.4.0, prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.0.0, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- The template is a guideline, not a test :) All PRs are welcome! -->

## Description
Adds a language selector component and places it in the header.

Because we're using the i18n http backend to load translation files, we don't know at runtime what languages are available, so for now I've just added an enum to the app containing available languages. Kind of defeats the purpose of loading them this way, but am keeping options open until I see what the crowdin integration ends up looking like.

Either going to leave this unmerged until we have a second translation completed, or merge it and remove `de` from `AvailableLanguage` to keep it hidden until needed.

### TODO
* add link to contribute translations to menu

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I've made my changes in a separate `fix/` or `feature/` branch
- [ ] My change requires a change to the documentation/website
- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md) and [CODE_OF_CONDUCT.md](../CODE_OF_CONDUCT.md)
- [ ] I've written tests to cover my change
- [ ] My change is passing new and existing tests
